### PR TITLE
fix(book-app): support partial matching in author search

### DIFF
--- a/samples/book-app-project/books.py
+++ b/samples/book-app-project/books.py
@@ -72,8 +72,11 @@ class BookCollection:
         return False
 
     def find_by_author(self, author: str) -> List[Book]:
-        """Find all books by a given author."""
-        return [b for b in self.books if b.author.lower() == author.lower()]
+        """Find all books by a given author (supports partial matching)."""
+        normalized_author = author.strip().lower()
+        if not normalized_author:
+            return []
+        return [b for b in self.books if normalized_author in b.author.lower()]
 
     def list_by_year(self, start: int, end: int) -> List[Book]:
         """Find books published within an inclusive year range."""

--- a/samples/book-app-project/tests/test_books.py
+++ b/samples/book-app-project/tests/test_books.py
@@ -105,3 +105,93 @@ def test_get_unread_books_returns_independent_list():
     unread.clear()
     
     assert len(collection.books) == 1
+
+
+def test_find_by_author_exact_match():
+    """Exact match for author name returns correct books."""
+    collection = BookCollection()
+    collection.add_book("1984", "George Orwell", 1949)
+    collection.add_book("Animal Farm", "George Orwell", 1945)
+    collection.add_book("Dune", "Frank Herbert", 1965)
+    
+    result = collection.find_by_author("George Orwell")
+    assert len(result) == 2
+    assert result[0].title == "1984"
+    assert result[1].title == "Animal Farm"
+
+
+def test_find_by_author_partial_match_first_name():
+    """Partial match with first name returns correct books."""
+    collection = BookCollection()
+    collection.add_book("1984", "George Orwell", 1949)
+    collection.add_book("Animal Farm", "George Orwell", 1945)
+    collection.add_book("Dune", "Frank Herbert", 1965)
+    
+    result = collection.find_by_author("George")
+    assert len(result) == 2
+
+
+def test_find_by_author_partial_match_last_name():
+    """Partial match with last name returns correct books."""
+    collection = BookCollection()
+    collection.add_book("1984", "George Orwell", 1949)
+    collection.add_book("Animal Farm", "George Orwell", 1945)
+    collection.add_book("Dune", "Frank Herbert", 1965)
+    
+    result = collection.find_by_author("Orwell")
+    assert len(result) == 2
+
+
+def test_find_by_author_case_insensitive():
+    """Author search is case insensitive."""
+    collection = BookCollection()
+    collection.add_book("1984", "George Orwell", 1949)
+    
+    result = collection.find_by_author("GEORGE ORWELL")
+    assert len(result) == 1
+    assert result[0].title == "1984"
+    
+    result = collection.find_by_author("george orwell")
+    assert len(result) == 1
+
+
+def test_find_by_author_empty_string():
+    """Empty author string returns empty list."""
+    collection = BookCollection()
+    collection.add_book("1984", "George Orwell", 1949)
+    
+    result = collection.find_by_author("")
+    assert result == []
+
+
+def test_find_by_author_whitespace_only():
+    """Whitespace-only author string returns empty list."""
+    collection = BookCollection()
+    collection.add_book("1984", "George Orwell", 1949)
+    
+    result = collection.find_by_author("   ")
+    assert result == []
+
+
+def test_find_by_author_no_match():
+    """Non-existent author returns empty list."""
+    collection = BookCollection()
+    collection.add_book("1984", "George Orwell", 1949)
+    
+    result = collection.find_by_author("Unknown Author")
+    assert result == []
+
+
+def test_search_books_author_partial_match():
+    """search_books with partial author match returns correct books."""
+    collection = BookCollection()
+    collection.add_book("1984", "George Orwell", 1949)
+    collection.add_book("Animal Farm", "George Orwell", 1945)
+    collection.add_book("Dune", "Frank Herbert", 1965)
+    
+    result = collection.search_books(author="George")
+    assert len(result) == 2
+    
+    result = collection.search_books(author="Herbert")
+    assert len(result) == 1
+


### PR DESCRIPTION
## 概要

Issue #4 で報告された著者名の検索で部分一致が正常に動かない問題を修正しました。

## 修正内容

### find_by_author() メソッドの修正
- `==` 演算子から `in` 演算子に変更し、部分一致に対応
- 入力値の前後の空白を削除（strip）
- 空文字列チェックを追加
- search_books() メソッドとの実装の一貫性を実現

### テスト追加
以下の 8 つの包括的なテストケースを追加しました：
- `test_find_by_author_exact_match` - 完全一致
- `test_find_by_author_partial_match_first_name` - 名前による部分一致
- `test_find_by_author_partial_match_last_name` - 姓による部分一致
- `test_find_by_author_case_insensitive` - 大文字小文字の区別なし
- `test_find_by_author_empty_string` - 空文字列の処理
- `test_find_by_author_whitespace_only` - 空白のみの処理
- `test_find_by_author_no_match` - マッチなしの処理
- `test_search_books_author_partial_match` - search_books の部分一致

## テスト結果

✅ 既存テスト：10 個すべて合格（回帰なし）
✅ 新規テスト：8 個全て合格
✅ **総合テスト：18 個すべて合格**

```
tests/test_books.py::test_find_by_author_exact_match PASSED
tests/test_books.py::test_find_by_author_partial_match_first_name PASSED
tests/test_books.py::test_find_by_author_partial_match_last_name PASSED
tests/test_books.py::test_find_by_author_case_insensitive PASSED
tests/test_books.py::test_find_by_author_empty_string PASSED
tests/test_books.py::test_find_by_author_whitespace_only PASSED
tests/test_books.py::test_find_by_author_no_match PASSED
tests/test_books.py::test_search_books_author_partial_match PASSED

18 passed in 0.15s ✓
```

## 実装の比較

**修正前（バグあり）：**
```python
# 完全一致のみ
find_by_author("George") → 0 books ✗
```

**修正後（修正済み）：**
```python
# 部分一致に対応
find_by_author("George") → 2 books ✓
find_by_author("Orwell") → 2 books ✓
```

## 関連 Issue

Closes #4
